### PR TITLE
remove the conversion of ui32 in TorchIndexSelect for disc backend

### DIFF
--- a/xla/client/lib/slicing.cc
+++ b/xla/client/lib/slicing.cc
@@ -281,11 +281,6 @@ XlaOp TorchIndexSelect(XlaOp input, XlaOp index, int64_t dim,
           "Gather dim must be greater than or equal to the number of batch "
           "dims");
     }
-    if (ShapeUtil::ElementHasBitWidth(index_shape, 64) &&
-        input_shape.dimensions(dim) < std::numeric_limits<uint32_t>::max()) {
-      index = ConvertElementType(index, U32);
-      index_shape.set_element_type(U32);
-    }
     std::vector<int64_t> slice_sizes = SpanToVector(input_shape.dimensions());
     GatherDimensionNumbers gather_dnums;
     gather_dnums.set_index_vector_dim(index_shape.rank());


### PR DESCRIPTION
This commit removes the conversion of ui32 because disc backend does not support this.

- test pass for openxla backend: `bazel test //xla/client/lib:slicing_test`
- torch xla tests pass: `python test/test_core_aten_ops.py AtenOpTest.test_aten_index_select_0` to `python test/test_core_aten_ops.py AtenOpTest.test_aten_index_select_5`
- also test llama 1b accuracy for openxla backend